### PR TITLE
ldelf.c: Always consider -L args and don't search for libs using ld.so.conf

### DIFF
--- a/ld/ld.texi
+++ b/ld/ld.texi
@@ -2355,7 +2355,9 @@ For a linker for a Linux system, if the file @file{/etc/ld.so.conf}
 exists, the list of directories found in that file.  Note: the path
 to this file is prefixed with the @code{sysroot} value, if that is
 defined, and then any @code{prefix} string if the linker was
-configured with the @command{--prefix=<path>} option.
+configured with the @command{--prefix=<path>} option. This has feature has
+been disabled on Gentoo Linux to make it consistent with the other
+linkers, which do not do this.
 @item
 For a native linker on a FreeBSD system, any directories specified by
 the @code{_PATH_ELF_HINTS} macro defined in the @file{elf-hints.h}

--- a/ld/ldelf.c
+++ b/ld/ldelf.c
@@ -1156,10 +1156,6 @@ ldelf_handle_dt_needed (struct elf_link_hash_table *htab,
 	      if (is_freebsd
 		  && ldelf_check_ld_elf_hints (l, force, elfsize))
 		break;
-
-	      if (is_linux
-		  && ldelf_check_ld_so_conf (l, force, elfsize, prefix))
-		break;
 	    }
 
 	  len = strlen (l->name);

--- a/ld/ldelf.c
+++ b/ld/ldelf.c
@@ -1090,8 +1090,8 @@ ldelf_handle_dt_needed (struct elf_link_hash_table *htab,
 	 linker will search.  That means that we want to use
 	 rpath_link, rpath, then the environment variable
 	 LD_LIBRARY_PATH (native only), then the DT_RPATH/DT_RUNPATH
-	 entries (native only), then the linker script LIB_SEARCH_DIRS.
-	 We do not search using the -L arguments.
+	 entries (native only), then the linker script LIB_SEARCH_DIRS,
+	 then the -L arguments.
 
 	 We search twice.  The first time, we skip objects which may
 	 introduce version mismatches.  The second time, we force
@@ -1165,11 +1165,7 @@ ldelf_handle_dt_needed (struct elf_link_hash_table *htab,
 	  len = strlen (l->name);
 	  for (search = search_head; search != NULL; search = search->next)
 	    {
-	      char *filename;
-
-	      if (search->cmdline)
-		continue;
-	      filename = (char *) xmalloc (strlen (search->name) + len + 2);
+	      char *filename = (char *) xmalloc (strlen (search->name) + len + 2);
 	      sprintf (filename, "%s/%s", search->name, l->name);
 	      nn.name = filename;
 	      if (ldelf_try_needed (&nn, force, is_linux))


### PR DESCRIPTION
The first of these changes fixes two related issues with prefixed and crossdev environments. The prefix issue is detailed in [Gentoo bug #892549](https://bugs.gentoo.org/892549). The crossdev issue can be reproduced by trying something like:

```
USE="-python icu" aarch64-unknown-linux-gnu-emerge libxml2
```

The second of these changes is not essential, but it does make bfd's behaviour in this area more consistent with the other linkers, which have not experienced these issues at all.

I'm not sure what upstream will make of these changes, particularly the second one, but it is interesting that even gold does not behave the same way as bfd here. Perhaps we can give them some exposure in Gentoo for a while before seeing what they think. The second change would not be submitted upstream as-is because fully removing the ld.so.conf feature is a much bigger diff.

Arsen also has some wider toolchain ideas that _may_ render these changes unnecessary, but tangible results could be some way off, and I'm honestly not convinced. I'll see what he comes up with though.