### PR TITLE
ld: Always consider -L args and allow a Gentoo-specific prefix override

### DIFF
--- a/ld/emultempl/elf.em
+++ b/ld/emultempl/elf.em
@@ -142,7 +142,7 @@ gld${EMULATION_NAME}_before_plugin_all_symbols_read (void)
   ldelf_before_plugin_all_symbols_read ($IS_LIBPATH, $IS_NATIVE,
 				        $IS_LINUX_TARGET,
 					$IS_FREEBSD_TARGET,
-					$ELFSIZE, "$prefix");
+					$ELFSIZE, "${gentoo_prefix-${prefix}}");
 }
 
 /* This is called after all the input files have been opened.  */
@@ -151,7 +151,7 @@ static void
 gld${EMULATION_NAME}_after_open (void)
 {
   ldelf_after_open ($IS_LIBPATH, $IS_NATIVE,
-		    $IS_LINUX_TARGET, $IS_FREEBSD_TARGET, $ELFSIZE, "$prefix");
+		    $IS_LINUX_TARGET, $IS_FREEBSD_TARGET, $ELFSIZE, "${gentoo_prefix-${prefix}}");
 }
 
 EOF

--- a/ld/ldelf.c
+++ b/ld/ldelf.c
@@ -1093,8 +1093,8 @@ ldelf_handle_dt_needed (struct elf_link_hash_table *htab,
 	 linker will search.  That means that we want to use
 	 rpath_link, rpath, then the environment variable
 	 LD_LIBRARY_PATH (native only), then the DT_RPATH/DT_RUNPATH
-	 entries (native only), then the linker script LIB_SEARCH_DIRS.
-	 We do not search using the -L arguments.
+	 entries (native only), then the linker script LIB_SEARCH_DIRS,
+	 then the -L arguments.
 
 	 We search twice.  The first time, we skip objects which may
 	 introduce version mismatches.  The second time, we force
@@ -1168,11 +1168,7 @@ ldelf_handle_dt_needed (struct elf_link_hash_table *htab,
 	  len = strlen (l->name);
 	  for (search = search_head; search != NULL; search = search->next)
 	    {
-	      char *filename;
-
-	      if (search->source != search_dir_linker_script)
-		continue;
-	      filename = (char *) xmalloc (strlen (search->name) + len + 2);
+	      char *filename = (char *) xmalloc (strlen (search->name) + len + 2);
 	      sprintf (filename, "%s/%s", search->name, l->name);
 	      nn.name = filename;
 	      if (ldelf_try_needed (&nn, force, is_linux))


### PR DESCRIPTION
The first of these changes fixes two related issues with prefixed and crossdev environments. The prefix issue is detailed in [Gentoo bug #892549](https://bugs.gentoo.org/892549). The crossdev issue can be reproduced by trying something like:

```
USE="-python icu" aarch64-unknown-linux-gnu-emerge libxml2
```

The second of these changes is prefix-specific and almost mentioned in [Gentoo bug #892549](https://bugs.gentoo.org/892549).

The prefix passed to ld.bfd is only used to locate `$prefix/etc/ld.so.conf`, with `$prefix` usually being `/usr`. This file is important on Gentoo Prefix systems, where the `/usr` prefix is within another directory. The problem is that Gentoo already passes the same directory as the sysroot, and ld.bfd therefore looks for `/myprefix/myprefix/usr/etc/ld.so.conf`.

In short, we need to pass our own "unprefixed" value, except in the Gentoo prefix-guest case, where we need to preserve the existing behaviour. The binutils ebuild will be responsible for setting this variable appropriately.

This supersedes #4.